### PR TITLE
Optional support for Parsing Postgres positional params

### DIFF
--- a/src/parsesql.nim
+++ b/src/parsesql.nim
@@ -402,7 +402,7 @@ proc getTok(c: var SqlLexer, tok: var Token) =
     else:
       getSymbol(c, tok)
   of '$':
-    when defined parseSqlAllowPositionalParams:
+    when parseSqlAllowPositionalParams == true:
       if c.buf[c.bufpos + 1] in {'0'..'9'}:
         # Accept positional parameters like $1, $2, $123 as a single identifier token.
         # Otherwise keep existing dollar-quoted string behavior.

--- a/src/parsesql.nim
+++ b/src/parsesql.nim
@@ -63,10 +63,7 @@ const
     "select", "from", "where", "group", "limit", "offset", "having",
     # functions
     "count",
-  ]
-
-  parseSqlAllowPositionalParams {.booldefine.} = false
-    
+  ] 
 
 proc close(L: var SqlLexer) =
   lexbase.close(L)
@@ -402,22 +399,19 @@ proc getTok(c: var SqlLexer, tok: var Token) =
     else:
       getSymbol(c, tok)
   of '$':
-    when parseSqlAllowPositionalParams == true:
-      if c.buf[c.bufpos + 1] in {'0'..'9'}:
-        # Accept positional parameters like $1, $2, $123 as a single identifier token.
-        # Otherwise keep existing dollar-quoted string behavior.
-        var pos = c.bufpos
-        add(tok.literal, c.buf[pos]) # leading $
+    if c.buf[c.bufpos + 1] in {'0'..'9'}:
+      # Accept positional parameters like $1, $2, $123 as a single identifier token.
+      # Otherwise keep existing dollar-quoted string behavior.
+      var pos = c.bufpos
+      add(tok.literal, c.buf[pos]) # leading $
+      inc(pos)
+      # read one or more digits
+      while c.buf[pos] in {'0'..'9'}:
+        add(tok.literal, c.buf[pos])
         inc(pos)
-        # read one or more digits
-        while c.buf[pos] in {'0'..'9'}:
-          add(tok.literal, c.buf[pos])
-          inc(pos)
-        c.bufpos = pos
-        tok.kind = tkIdentifier
-      else: getDollarString(c, tok)
-    else:
-      getDollarString(c, tok)
+      c.bufpos = pos
+      tok.kind = tkIdentifier
+    else: getDollarString(c, tok)
   of '[':
     tok.kind = tkBracketLe
     inc(c.bufpos)

--- a/src/parsesql.nim
+++ b/src/parsesql.nim
@@ -65,6 +65,9 @@ const
     "count",
   ]
 
+  parseSqlAllowPositionalParams {.booldefine.} = false
+    
+
 proc close(L: var SqlLexer) =
   lexbase.close(L)
 
@@ -398,7 +401,23 @@ proc getTok(c: var SqlLexer, tok: var Token) =
       getBitHexString(c, tok, {'a'..'f', 'A'..'F', '0'..'9'})
     else:
       getSymbol(c, tok)
-  of '$': getDollarString(c, tok)
+  of '$':
+    when defined parseSqlAllowPositionalParams:
+      if c.buf[c.bufpos + 1] in {'0'..'9'}:
+        # Accept positional parameters like $1, $2, $123 as a single identifier token.
+        # Otherwise keep existing dollar-quoted string behavior.
+        var pos = c.bufpos
+        add(tok.literal, c.buf[pos]) # leading $
+        inc(pos)
+        # read one or more digits
+        while c.buf[pos] in {'0'..'9'}:
+          add(tok.literal, c.buf[pos])
+          inc(pos)
+        c.bufpos = pos
+        tok.kind = tkIdentifier
+      else: getDollarString(c, tok)
+    else:
+      getDollarString(c, tok)
   of '[':
     tok.kind = tkBracketLe
     inc(c.bufpos)

--- a/tests/main/test1.nim
+++ b/tests/main/test1.nim
@@ -302,3 +302,10 @@ SELECT `SELECT`, `FROM` as `GROUP` FROM `WHERE`;
 doAssert $parseSql("""
 SELECT "SELECT", "FROM" as "GROUP" FROM "WHERE";
 """) == """select "SELECT", "FROM" as "GROUP" from "WHERE";"""
+
+# parse positional parameters
+doAssert $parseSql("""SELECT * FROM table WHERE id = $1 AND name = $2;
+""") == "select * from table where id = $1 and name = $2;" 
+
+doAssert $parseSql("""INSERT INTO table (id, name) VALUES ($1, $2);
+""") == "insert into table (id , name ) values ($1 , $2 );"

--- a/tests/main/test1.nim
+++ b/tests/main/test1.nim
@@ -2,7 +2,7 @@ discard """
   matrix: "--mm:refc; --mm:orc"
   targets: "c js"
 """
-import parsesql
+import ../../src/parsesql
 import std/assertions
 
 doAssert treeRepr(parseSql("INSERT INTO STATS VALUES (10, 5.5); ")

--- a/tests/main/test1.nims
+++ b/tests/main/test1.nims
@@ -1,1 +1,0 @@
---define:parseSqlAllowPositionalParams

--- a/tests/main/test1.nims
+++ b/tests/main/test1.nims
@@ -1,0 +1,1 @@
+--define:parseSqlAllowPositionalParams


### PR DESCRIPTION
Added parsing support for SQL queries containing PostgreSQL-style positional parameters (`$1`, `$2`, etc.). The feature is optional and requires `-d:parseSqlAllowPositionalParams`